### PR TITLE
Add extension to forward Leaflet click coords

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,8 @@
+// Background service worker: logs received coordinates
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'coords' && message.payload) {
+    const { lat, lon } = message.payload;
+    console.log('Coordinates received:', lat, lon);
+  }
+});
+

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,12 @@
+// Content script: listens for messages from the page and forwards them
+// to the background script
+window.addEventListener('message', (event) => {
+  // Only accept messages from the same page
+  if (event.source !== window) return;
+
+  const data = event.data;
+  if (data && data.type === 'coords' && data.payload) {
+    chrome.runtime.sendMessage({ type: 'coords', payload: data.payload });
+  }
+});
+

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Leaflet Coordinates Listener",
+  "version": "1.0",
+  "description": "Listen to Leaflet clicks and log coords in background.",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_script.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
     var lat = e.latlng.lat.toFixed(6);
     var lng = e.latlng.lng.toFixed(6);
     document.getElementById('coords').textContent = 'Latitude: ' + lat + ', Longitude: ' + lng;
+    // envoyer les coordonnees a l'extension
+    window.postMessage({ type: "coords", payload: { lat: lat, lon: lng } }, "*");
   });
 </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- show clicked coords on page and send them with `window.postMessage`
- add Chrome extension with content script and background service worker

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a7160829c832c8a7c8fb9d33ce7dc