### PR TITLE
Add Chrome extension integration

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,6 @@
+// Background service worker for the extension
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'coords' && message.payload) {
+    console.log('Received coordinates:', message.payload.lat, message.payload.lon);
+  }
+});

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,13 @@
+// Listen for messages posted from the webpage
+window.addEventListener('message', (event) => {
+  // Only accept messages from the same page
+  if (event.source !== window) {
+    return;
+  }
+
+  const data = event.data;
+  if (data && data.type === 'coords') {
+    // Forward the coordinates to the background script
+    chrome.runtime.sendMessage(data);
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "Leaflet Coords Logger",
+  "version": "1.0",
+  "description": "Logs clicked coordinates from a Leaflet map.",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_script.js"]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
     var lat = e.latlng.lat.toFixed(6);
     var lng = e.latlng.lng.toFixed(6);
     document.getElementById('coords').textContent = 'Latitude: ' + lat + ', Longitude: ' + lng;
+    window.postMessage({
+      type: 'coords',
+      payload: { lat: lat, lon: lng }
+    }, '*');
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- capture clicked coordinates on the Leaflet map
- send coordinates to an extension via `window.postMessage`
- add Chrome extension files to log the coordinates in the background service worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a716484f8832c9e46a9c2f9ee1447