### PR TITLE
Add Chrome extension for map coordinates

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,8 @@
+// background.js
+// Affiche dans la console les coordonnees recues du content script
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'coords' && message.payload) {
+    console.log('Coordonnees recues:', message.payload.lat, message.payload.lon);
+  }
+});

--- a/chrome-extension/content_script.js
+++ b/chrome-extension/content_script.js
@@ -1,0 +1,16 @@
+// content_script.js
+// Ecoute les messages de la page et transfere les coordonnees au background
+
+// Only accept messages from the same window
+window.addEventListener('message', (event) => {
+  if (event.source !== window) return; // ignore cross-origin or iframes
+
+  const data = event.data;
+  if (data && data.type === 'coords') {
+    // Transfert des coordonnees au background
+    chrome.runtime.sendMessage({
+      type: 'coords',
+      payload: data.payload
+    });
+  }
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Leaflet Coordinates Listener",
+  "version": "1.0",
+  "description": "Listen for coordinates posted from a Leaflet map and log them.",
+  "permissions": [],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "Coords Listener"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
     var lat = e.latlng.lat.toFixed(6);
     var lng = e.latlng.lng.toFixed(6);
     document.getElementById('coords').textContent = 'Latitude: ' + lat + ', Longitude: ' + lng;
+    // Envoie les coordonnées à l'extension Chrome via window.postMessage
+    window.postMessage({
+      type: 'coords',
+      payload: { lat: lat, lon: lng }
+    }, '*');
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add Chrome extension to log coordinates clicked on map
- post coordinates to extension from `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a716ff01c832c83855cf3fbb74ccc