### PR TITLE
Implement WebMercator URL opener

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,46 @@
-// background.js
-// Receive messages from the content script and log coordinates
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.type === 'coords' && message.payload) {
-    console.log('Coordinates received:', message.payload.lat, message.payload.lon);
+// background.js - Chrome Extension Service Worker (MV3)
+// Listen for coordinate messages and open the ArcGIS viewer around them.
+
+// Keep the timestamp of the last processed message to debounce events.
+let lastProcessed = 0;
+
+/**
+ * Convert WGS84 latitude/longitude to Web Mercator coordinates.
+ * @param {number} lat Latitude in decimal degrees
+ * @param {number} lon Longitude in decimal degrees
+ * @returns {{x:number, y:number}} Coordinates in meters
+ */
+function latLonToWebMercator(lat, lon) {
+  const R = 6_378_137; // Earth radius in meters
+  const rad = Math.PI / 180;
+  const x = R * lon * rad;
+  const y = R * Math.log(Math.tan(Math.PI / 4 + (lat * rad) / 2));
+  return { x, y };
+}
+
+// Handle messages sent from content scripts or other parts of the extension.
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type !== 'coords' || !message.payload) {
+    return;
   }
+
+  const { lat, lon } = message.payload;
+  if (typeof lat !== 'number' || typeof lon !== 'number') {
+    return; // Ignore malformed messages
+  }
+
+  const now = Date.now();
+  if (now - lastProcessed < 1000) {
+    return; // Ignore events fired less than 1s apart
+  }
+  lastProcessed = now;
+
+  const { x, y } = latLonToWebMercator(lat, lon);
+  const buf = 1000;
+  const url =
+    `https://www.arcgis.com/apps/webappviewer/index.html` +
+    `?id=bece6e542e4c42e0ba9374529c7de44c` +
+    `&extent=${x - buf},${y - buf},${x + buf},${y + buf},102100`;
+
+  chrome.tabs.create({ url });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,6 @@
       "run_at": "document_idle"
     }
   ],
-  "host_permissions": ["https://www.arcgis.com/*"]
+  "host_permissions": ["https://www.arcgis.com/*"],
+  "permissions": ["tabs"]
 }


### PR DESCRIPTION
## Summary
- overhaul `background.js` to open ArcGIS viewer on received coordinates
- debounce messages received within 1 s to avoid repeated tab opening
- add `permissions` entry to manifest for `chrome.tabs`

## Testing
- `node --check background.js`
- `jq . manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_687a75c93b34832c92bcf6eb0d142207