### PR TITLE
Reuse ArcGIS tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,11 @@
 // background.js - Chrome Extension Service Worker (MV3)
 // Listen for coordinate messages and open the ArcGIS viewer around them.
 
-// Keep the timestamp of the last processed message to debounce events.
+// Keep the timestamp of the last processed message to debounce events (<1s)
 let lastProcessed = 0;
+
+// Id of the ArcGIS tab reused between analyses
+let arcgisTabId = null;
 
 /**
  * Convert WGS84 latitude/longitude to Web Mercator coordinates.
@@ -16,6 +19,22 @@ function latLonToWebMercator(lat, lon) {
   const x = R * lon * rad;
   const y = R * Math.log(Math.tan(Math.PI / 4 + (lat * rad) / 2));
   return { x, y };
+}
+
+/**
+ * Build the ArcGIS viewer URL centered on the provided coordinates.
+ * @param {number} lat
+ * @param {number} lon
+ * @returns {string}
+ */
+function buildUrl(lat, lon) {
+  const { x, y } = latLonToWebMercator(lat, lon);
+  const buf = 1000; // 1 km buffer around the point
+  return (
+    'https://www.arcgis.com/apps/webappviewer/index.html' +
+    '?id=bece6e542e4c42e0ba9374529c7de44c' +
+    `&extent=${x - buf},${y - buf},${x + buf},${y + buf},102100`
+  );
 }
 
 // Handle messages sent from content scripts or other parts of the extension.
@@ -35,12 +54,29 @@ chrome.runtime.onMessage.addListener((message) => {
   }
   lastProcessed = now;
 
-  const { x, y } = latLonToWebMercator(lat, lon);
-  const buf = 1000;
-  const url =
-    `https://www.arcgis.com/apps/webappviewer/index.html` +
-    `?id=bece6e542e4c42e0ba9374529c7de44c` +
-    `&extent=${x - buf},${y - buf},${x + buf},${y + buf},102100`;
+  const url = buildUrl(lat, lon);
 
-  chrome.tabs.create({ url });
+  if (arcgisTabId !== null) {
+    chrome.tabs.get(arcgisTabId, (tab) => {
+      if (chrome.runtime.lastError || !tab) {
+        chrome.tabs.create({ url }).then((newTab) => {
+          arcgisTabId = newTab.id;
+        });
+      } else {
+        chrome.tabs.update(arcgisTabId, { url, active: true });
+      }
+    });
+  } else {
+    chrome.tabs.create({ url }).then((newTab) => {
+      arcgisTabId = newTab.id;
+    });
+  }
 });
+
+// Reset the stored tab id when the tab is closed
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabId === arcgisTabId) {
+    arcgisTabId = null;
+  }
+});
+


### PR DESCRIPTION
## Summary
- reuse the same ArcGIS tab instead of opening a new one for each analysis
- keep debounce and WebMercator logic

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687a79329eb4832cb8d642609eef1101