### PR TITLE
Implement veg status feedback

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,6 +7,8 @@ let lastProcessed = 0;
 // Id of the ArcGIS tab reused between analyses
 let arcgisTabId = null;
 let lastVegOptions = { scaleMin: '1:100', transparency: 0.5 };
+// Id of the tab that sent the last coordinates message (Netlify page)
+let senderTabId = null;
 
 // Send a veg:init message when the ArcGIS tab finishes loading
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
@@ -46,54 +48,70 @@ function buildUrl(lat, lon) {
 }
 
 // Handle messages sent from content scripts or other parts of the extension.
-chrome.runtime.onMessage.addListener((message) => {
-  if (message?.type !== 'coords' || !message.payload) {
+chrome.runtime.onMessage.addListener((message, sender) => {
+  // Handle coordinate messages sent from the Netlify page
+  if (message?.type === 'coords' && message.payload) {
+    // Remember the tab that triggered the analysis
+    senderTabId = sender?.tab?.id ?? null;
+
+    const { lat, lon } = message.payload;
+    if (typeof lat !== 'number' || typeof lon !== 'number') {
+      return; // Ignore malformed messages
+    }
+
+    lastVegOptions = message.options || lastVegOptions;
+    console.info('[bg] options', lastVegOptions);
+
+    const now = Date.now();
+    if (now - lastProcessed < 1000) {
+      return; // Ignore events fired less than 1s apart
+    }
+    lastProcessed = now;
+
+    const url = buildUrl(lat, lon);
+
+    if (arcgisTabId !== null) {
+      chrome.tabs.get(arcgisTabId, (tab) => {
+        if (chrome.runtime.lastError || !tab) {
+          chrome.tabs.create({ url }).then((newTab) => {
+            arcgisTabId = newTab.id;
+            chrome.tabs.sendMessage(newTab.id, {
+              type: 'veg:update',
+              options: lastVegOptions
+            });
+          });
+        } else {
+          chrome.tabs.update(arcgisTabId, { url, active: true }).then(() => {
+            chrome.tabs.sendMessage(arcgisTabId, {
+              type: 'veg:update',
+              options: lastVegOptions
+            });
+          });
+        }
+      });
+    } else {
+      chrome.tabs.create({ url }).then((newTab) => {
+        arcgisTabId = newTab.id;
+        chrome.tabs.sendMessage(newTab.id, {
+          type: 'veg:update',
+          options: lastVegOptions
+        });
+      });
+    }
     return;
   }
 
-  const { lat, lon } = message.payload;
-  if (typeof lat !== 'number' || typeof lon !== 'number') {
-    return; // Ignore malformed messages
-  }
-
-  lastVegOptions = message.options || lastVegOptions;
-  console.info('[bg] options', lastVegOptions);
-
-  const now = Date.now();
-  if (now - lastProcessed < 1000) {
-    return; // Ignore events fired less than 1s apart
-  }
-  lastProcessed = now;
-
-  const url = buildUrl(lat, lon);
-
-  if (arcgisTabId !== null) {
-    chrome.tabs.get(arcgisTabId, (tab) => {
-      if (chrome.runtime.lastError || !tab) {
-        chrome.tabs.create({ url }).then((newTab) => {
-          arcgisTabId = newTab.id;
-          chrome.tabs.sendMessage(newTab.id, {
-            type: 'veg:update',
-            options: lastVegOptions
-          });
-        });
-      } else {
-        chrome.tabs.update(arcgisTabId, { url, active: true }).then(() => {
-          chrome.tabs.sendMessage(arcgisTabId, {
-            type: 'veg:update',
-            options: lastVegOptions
-          });
-        });
-      }
-    });
-  } else {
-    chrome.tabs.create({ url }).then((newTab) => {
-      arcgisTabId = newTab.id;
-      chrome.tabs.sendMessage(newTab.id, {
-        type: 'veg:update',
-        options: lastVegOptions
+  // Forward vegetation status messages to the originating Netlify tab
+  if (message?.type === 'veg:ready' || message?.type === 'veg:error') {
+    const status = message.type === 'veg:ready' ? 'ready' : 'error';
+    if (senderTabId != null) {
+      // Relay the vegetation processing status back to the Netlify page
+      chrome.tabs.sendMessage(senderTabId, {
+        type: 'veg:status',
+        status,
+        error: message.error
       });
-    });
+    }
   }
 });
 

--- a/content_script.js
+++ b/content_script.js
@@ -15,3 +15,15 @@ window.addEventListener('message', (event) => {
     });
   }
 });
+
+// Listen for vegetation status updates coming from the background script
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg?.type === 'veg:status') {
+    // Forward the status to the page so the DOM can react
+    window.postMessage({
+      type: 'veg:status',
+      status: msg.status,
+      error: msg.error
+    }, '*');
+  }
+});

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <option value="1:100 000"></option>
   </datalist>
 </form>
+<div id="status" style="padding:8px;font-family:sans-serif;"></div>
 <div id="map"></div>
 <div id="coords">Cliquez sur la carte pour afficher les coordonnées</div>
 <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
@@ -37,6 +38,30 @@
 
   // Currently displayed temporary marker (if any)
   var pendingMarker;
+
+  // Display element for vegetation layer status
+  var statusEl = document.getElementById('status');
+  var hideTimer;
+
+  // Listen for status messages coming from the extension
+  window.addEventListener('message', function(ev) {
+    if (ev.data && ev.data.type === 'veg:status') {
+      if (ev.data.status === 'ready') {
+        statusEl.textContent = '✓ Végétation appliquée';
+        statusEl.style.background = '#c8e6c9';
+        statusEl.style.color = '#2e7d32';
+      } else {
+        statusEl.textContent = '✗ Échec: ' + ev.data.error;
+        statusEl.style.background = '#ffcdd2';
+        statusEl.style.color = '#c62828';
+      }
+      statusEl.style.display = 'block';
+      clearTimeout(hideTimer);
+      hideTimer = setTimeout(function() {
+        statusEl.style.display = 'none';
+      }, 5000);
+    }
+  });
 
   /**
    * Remove the temporary marker and associated listeners.


### PR DESCRIPTION
## Summary
- remember which tab initiated the vegetation request
- relay veg layer status from the ArcGIS tab to the Netlify page
- forward status to DOM via content script
- display status badge in the sample page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a826aa078832cbff5cb5f1a4b94de