### PR TITLE
Add dynamic soil map link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
 <div id="status" style="padding:8px;font-family:sans-serif;"></div>
 <div id="map"></div>
 <div id="coords">Cliquez sur la carte pour afficher les coordonnées</div>
+<div id="resources" style="padding:4px;font-family:sans-serif;">
+  <a id="soil-link" href="#" target="_blank" style="display:none;">Voir la carte des sols</a>
+</div>
 <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 <script>
   // Initialise the map and its tile layer
@@ -42,6 +45,19 @@
   // Display element for vegetation layer status
   var statusEl = document.getElementById('status');
   var hideTimer;
+  var soilLink = document.getElementById('soil-link');
+
+  function buildSoilUrl(lat, lon) {
+    return (
+      'https://www.geoportail.gouv.fr/carte?c=' +
+      lon +
+      ',' +
+      lat +
+      '&z=12&l0=ORTHOIMAGERY.ORTHOPHOTOS::GEOPORTAIL:OGC:WMTS(1)' +
+      '&l1=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR.CV::GEOPORTAIL:OGC:WMTS(1)' +
+      '&l2=INRA.CARTE.SOLS::GEOPORTAIL:OGC:WMTS(0.8)&permalink=yes'
+    );
+  }
 
   // Listen for status messages coming from the extension
   window.addEventListener('message', function(ev) {
@@ -98,6 +114,9 @@
     // Display the clicked coordinates below the map
     document.getElementById('coords').textContent =
       'Latitude: ' + lat.toFixed(6) + ', Longitude: ' + lon.toFixed(6);
+
+    soilLink.href = buildSoilUrl(lat, lon);
+    soilLink.style.display = 'inline';
 
     // Create a marker at the clicked position
     pendingMarker = L.marker([lat, lon]).addTo(map);


### PR DESCRIPTION
## Summary
- add a new link to open the soil map from the clicked position
- compute Geoportail URL based on the selected coordinates

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e0bee48a4832ca13eda9a854cfccc